### PR TITLE
doc: Mention generics when declaring TableSchemas

### DIFF
--- a/docs/tutorial.rst
+++ b/docs/tutorial.rst
@@ -147,6 +147,15 @@ And likewise for ``project`` and ``Project``::
         }
     }
 
+There is also some generics machinery available if you want to grab the field information from your Rel8able type::
+
+  projectSchema :: TableSchema (Project Name)
+  projectSchema = TableSchema
+    { name = "project"
+    , schema = Nothing
+    , columns = namesFromLabels @(Project Name)
+    }
+    
 
 .. note::
 


### PR DESCRIPTION
Do the generics actually do the same thing here, or will the names be different in this case?
